### PR TITLE
Enable state saving for DataTables across multiple admin pages

### DIFF
--- a/coordinator/admin/Emails/index.php
+++ b/coordinator/admin/Emails/index.php
@@ -316,6 +316,7 @@ HTML;
 
 	$(document).ready(function() {
 		var t = $('#em').DataTable({
+            stateSave: true,
 			// order: [[5	, 'desc']],
 			// paging: false,
 			lengthMenu: [

--- a/coordinator/admin/Emails/index.php
+++ b/coordinator/admin/Emails/index.php
@@ -190,9 +190,9 @@ foreach ($users_done as $user_name => $table) {
 		<td data-content=''>
 			$mail_icon
 		</td>
-		<td data-order='$user_group' data-search='$user_group' data-content='Project'>
+		<td data-order='$user_group2' data-search='$user_group2' data-content='Project'>
 			<!-- <select name='project_$numb' class='form-select options'>$ project_line</select> -->
-			<input class='form-control' size='25' name='project_$numb' value='$user_group' readonly/>
+			<input class='form-control' size='25' name='project_$numb' value='$user_group2' readonly/>
 		</td>
 		<td data-order='$wiki' data-search='$wiki2' data-content='Wiki'>
 			<input class='form-control' size='4' name='wiki_$numb' value='$wiki' readonly/>

--- a/coordinator/admin/Emails/index.php
+++ b/coordinator/admin/Emails/index.php
@@ -83,7 +83,7 @@ function get_sorted_array()
 function filter_table($project_name)
 {
 	//---
-	// TablesSql::$s_projects_title_to_id["empty"] = "empty";
+	TablesSql::$s_projects_title_to_id["empty"] = "empty";
 	//---
 	$l_list = <<<HTML
 		<option value='Uncategorized'>Uncategorized</option>
@@ -131,9 +131,7 @@ $limit = (isset($_GET['limit'])) ? $_GET['limit'] : 0;
 //---
 $main_project = (isset($_GET['project'])) ? $_GET['project'] : 'Uncategorized';
 //---
-if ($main_project == 'empty') {
-	$main_project = 'Uncategorized';
-}
+// if ($main_project == 'empty') { $main_project = 'Uncategorized'; }
 //---
 $project_filter = filter_table($main_project);
 //---

--- a/coordinator/admin/Emails/index.php
+++ b/coordinator/admin/Emails/index.php
@@ -86,7 +86,7 @@ function filter_table($project_name)
 	TablesSql::$s_projects_title_to_id["empty"] = "empty";
 	//---
 	$l_list = <<<HTML
-		<option value='Uncategorized'>Uncategorized</option>
+		<option data-tokens='all' value='All'>All</option>
 	HTML;
 	//---
 	foreach (TablesSql::$s_projects_title_to_id as $p_title => $p_id) {
@@ -129,7 +129,7 @@ $form_rows = '';
 //---
 $limit = (isset($_GET['limit'])) ? $_GET['limit'] : 0;
 //---
-$main_project = (isset($_GET['project'])) ? $_GET['project'] : 'Uncategorized';
+$main_project = (isset($_GET['project'])) ? $_GET['project'] : 'All';
 //---
 // if ($main_project == 'empty') { $main_project = 'Uncategorized'; }
 //---
@@ -147,7 +147,7 @@ foreach ($users_done as $user_name => $table) {
 	// ---
 	if ($user_group2 == '') $user_group2 = 'Uncategorized';
 	//---
-	if ($main_project != "" && $user_group2 != $main_project) {
+	if ($main_project != "" && $main_project != "All" && $user_group2 != $main_project) {
 		continue;
 	}
 	//---

--- a/coordinator/admin/Emails/index.php
+++ b/coordinator/admin/Emails/index.php
@@ -83,7 +83,7 @@ function get_sorted_array()
 function filter_table($project_name)
 {
 	//---
-	TablesSql::$s_projects_title_to_id["empty"] = "empty";
+	// TablesSql::$s_projects_title_to_id["empty"] = "empty";
 	//---
 	$l_list = <<<HTML
 		<option value='Uncategorized'>Uncategorized</option>
@@ -129,7 +129,11 @@ $form_rows = '';
 //---
 $limit = (isset($_GET['limit'])) ? $_GET['limit'] : 0;
 //---
-$main_project = (isset($_GET['project'])) ? $_GET['project'] : '';
+$main_project = (isset($_GET['project'])) ? $_GET['project'] : 'Uncategorized';
+//---
+if ($main_project == 'empty') {
+	$main_project = 'Uncategorized';
+}
 //---
 $project_filter = filter_table($main_project);
 //---
@@ -143,9 +147,7 @@ foreach ($users_done as $user_name => $table) {
 	//---
 	$user_group2 = $user_group;
 	// ---
-	if ($user_group2 == '') {
-		$user_group2 = 'empty';
-	}
+	if ($user_group2 == '') $user_group2 = 'Uncategorized';
 	//---
 	if ($main_project != "" && $user_group2 != $main_project) {
 		continue;
@@ -316,7 +318,7 @@ HTML;
 
 	$(document).ready(function() {
 		var t = $('#em').DataTable({
-            stateSave: true,
+			stateSave: true,
 			// order: [[5	, 'desc']],
 			// paging: false,
 			lengthMenu: [

--- a/coordinator/admin/pages_users_to_main/index.php
+++ b/coordinator/admin/pages_users_to_main/index.php
@@ -227,6 +227,7 @@ echo $recent_table;
 <script>
     $(document).ready(function() {
         var table = $('#pages_table').DataTable({
+            stateSave: true,
             // order: [[10	, 'desc']],
             // paging: false,
             lengthMenu: [

--- a/coordinator/admin/translated/index.php
+++ b/coordinator/admin/translated/index.php
@@ -191,6 +191,7 @@ echo $recent_table;
 <script>
     $(document).ready(function() {
         var t = $('#pages_table').DataTable({
+            stateSave: true,
             // order: [[10	, 'desc']],
             // paging: false,
             lengthMenu: [

--- a/coordinator/admin/tt/index.php
+++ b/coordinator/admin/tt/index.php
@@ -244,6 +244,7 @@ HTML;
 
 	$(document).ready(function() {
 		var t = $('#em').DataTable({
+            stateSave: true,
 			// order: [[5	, 'desc']],
 			// paging: false,
 			lengthMenu: [

--- a/coordinator/admin/wikirefs_options/index.php
+++ b/coordinator/admin/wikirefs_options/index.php
@@ -146,6 +146,7 @@ HTML;
 
     $(document).ready(function() {
         $('#em2').DataTable({
+            stateSave: true,
             lengthMenu: [
                 [10, 50, 100, 150],
                 [10, 50, 100, 150]

--- a/coordinator/tools/last.php
+++ b/coordinator/tools/last.php
@@ -257,12 +257,14 @@ echo $recent_table;
 
     $(document).ready(function() {
         var t = $('#last_tabel').DataTable({
+            stateSave: true,
             // order: [ [6, 'desc'] ],
             paging: false,
             // lengthMenu: [[100, 150, 200], [250, 150, 200]],
             // scrollY: 800
         });
         var t = $('#last_users_tabel').DataTable({
+            stateSave: true,
             order: [
                 [4, 'desc']
             ],

--- a/coordinator/tools/last_users.php
+++ b/coordinator/tools/last_users.php
@@ -248,12 +248,14 @@ echo $recent_table;
 
     $(document).ready(function() {
         var t = $('#last_tabel').DataTable({
+            stateSave: true,
             // order: [ [6, 'desc'] ],
             paging: false,
             // lengthMenu: [[100, 150, 200], [250, 150, 200]],
             // scrollY: 800
         });
         var t = $('#last_users_tabel').DataTable({
+            stateSave: true,
             order: [
                 [4, 'desc']
             ],

--- a/footer.php
+++ b/footer.php
@@ -37,11 +37,13 @@ if (isset($GLOBALS['time_start'])) {
 	});
 
 	$('.sortable').DataTable({
+		stateSave: true,
 		paging: false,
 		info: false,
 		searching: false
 	});
 	$('.sortable2').DataTable({
+		stateSave: true,
 		lengthMenu: [
 			[25, 50, 100, 200],
 			[25, 50, 100, 200]
@@ -56,6 +58,7 @@ if (isset($GLOBALS['time_start'])) {
 
 		setTimeout(function() {
 			$('.soro').DataTable({
+				stateSave: true,
 				lengthMenu: [
 					[25, 50, 100, 200],
 					[25, 50, 100, 200]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Tables throughout the application now preserve their state—including pagination, filtering, and sorting—across page reloads and revisits, enhancing user experience with consistent data views.
  - The email listing page defaults project filters and user group assignments to "Uncategorized" for clearer categorization and display consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->